### PR TITLE
Added a badge for the publish workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # MySQL Router Snap
+[![.github/workflows/publish.yaml](https://github.com/canonical/mysql-router-snap/actions/workflows/publish.yaml/badge.svg)](https://github.com/canonical/mysql-router-snap/actions/workflows/publish.yaml)
+
 This repository contains the packaging metadata for creating a snap of MySQL Router built from the official Ubuntu repositories.  For more information on snaps, visit [snapcraft.io](https://snapcraft.io/). 
 
 ## Installing the Snap


### PR DESCRIPTION
## Issue
This repo's status is not displayed in the [Charm Engineering Releases](https://releases.juju.is/?team=Data) overview.

## Solution
Added a badge for the "publish" workflow.

@ reviewers, does this make sense?